### PR TITLE
Allow syncing falsy properties

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -114,11 +114,11 @@ class Sync {
 			}
 		} else {
 			for (const key of Object.keys(oldObject)) {
-				if (!value[key]) delete oldObject[key];
+				if (value[key] === undefined) delete oldObject[key];
 			}
 			if (oldObject.default && value && value.default && isObject(oldObject.default) && isObject(value.default)) {
 				for (const key of Object.keys(oldObject.default)) {
-					if (!value.default[key]) delete oldObject.default[key];
+					if (value.default[key] === undefined) delete oldObject.default[key];
 				}
 			}
 			if (oldObject.default && value && value.default && isObject(oldObject.default) && isObject(value.default)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ class Sync {
 			}
 		} else {
 			for (const key of Object.keys(oldObject)) {
-				if (!value[key]) delete oldObject[key];
+				if (value[key] === undefined) delete oldObject[key];
 			}
 			Object.assign(oldObject, value);
 		}


### PR DESCRIPTION
zero.js:
```
module.exports.ZERO = 0
```

main.js:
```
const HeatSync = require("heatsync")
const sync = new HeatSync()
const zero = sync.require("./zero.js")
console.log(zero.ZERO) // ok
sync.require("./zero.js")
console.log(zero.ZERO) // where is my zero
```

Now fixed.