### PR TITLE
Another style of reloading class methods

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -278,15 +278,25 @@ class Sync {
 	reloadClassMethods(loadedClass) {
 		const first = getStack().first();
 		assert(first);
-		const key = `${first.srcAbsolute}:${loadedClass.name}`;
+		const abs = first.srcAbsolute;
 
-		if (Object.getPrototypeOf(loadedClass) !== this.ReloadableClass) throw new Error(`You tried to reload class ${key}, but it needs to \`extend sync.ReloadableClass\` (directly) for that to work.`);
+		const loadClass = loadedClass => {
+			const key = `${abs}:${loadedClass.name}`;
 
-		for (const ref of this._reloadableInstances.get(key) ?? []) {
-			const object = ref.deref();
-			if (!object) continue;
-			Object.setPrototypeOf(object, loadedClass.prototype);
+			if (Object.getPrototypeOf(loadedClass) !== this.ReloadableClass) throw new Error(`You tried to reload class ${key}, but it needs to \`extend sync.ReloadableClass\` (directly) for that to work.`);
+
+			for (const ref of this._reloadableInstances.get(key) ?? []) {
+				const object = ref.deref();
+				if (!object) continue;
+				Object.setPrototypeOf(object, loadedClass.prototype);
+			}
 		}
+
+		if ("prototype" in loadedClass) loadClass(loadedClass); // passed a class - load it
+		// @ts-ignore
+		else setImmediate(() => loadClass(loadedClass())); // passed a function - need to wait before we call it so that the reference is resolvable
+
+		return this.ReloadableClass;
 	}
 
 	/**

--- a/esm.mjs
+++ b/esm.mjs
@@ -273,7 +273,7 @@ class Sync {
 	}
 
 	/**
-	 * @param {Class} loadedClass
+	 * @param {Class | (() => Class | any)} loadedClass
 	 */
 	reloadClassMethods(loadedClass) {
 		const first = getStack().first();
@@ -293,7 +293,7 @@ class Sync {
 		}
 
 		if ("prototype" in loadedClass) loadClass(loadedClass); // passed a class - load it
-		// @ts-ignore
+		// @ts-expect-error
 		else setImmediate(() => loadClass(loadedClass())); // passed a function - need to wait before we call it so that the reference is resolvable
 
 		return this.ReloadableClass;

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,7 +289,7 @@ class Sync {
 		}
 
 		if ("prototype" in loadedClass) loadClass(loadedClass); // passed a class - load it
-		// @ts-ignore
+		// @ts-expect-error
 		else setImmediate(() => loadClass(loadedClass())); // passed a function - need to wait before we call it so that the reference is resolvable
 
 		return this.ReloadableClass;


### PR DESCRIPTION
Added example:

```
class ThisCanReload extends sync.reloadClassMethods(() => ThisCanReload) {
  constructor() { ... }
  magic() { ... }
}
// doesn't need a follow-up function call
```

This works because the hand side of `extends` can be an expression. Expression scope captures references even when they aren't initialised yet. So `reloadClassMethods` is informed about the class that we're making right now.

This is a more fool-proof way of invoking the class reloader because now it's impossible to forget to add the follow-up function call - because it's not needed! Just start writing `extends sync.reload` and TypeScript will help you fill in the rest.

The type `loadedClass: Class | (() => Class | any)` is mandatory. If `any` is not listed as a return value of the function then you'll get an interesting TypeScript error when trying to use this. Paste this into a standalone file and notice how there are no errors:

```
class Outer {}

/** @param {() => any} getInner */
function getOuter(getInner) {
   setTimeout(() => {
      console.log("this class just extended Outer:", getInner())
   })
   return Outer
}

class Inner extends getOuter(() => Inner) {}
```

If you change `any` to literally anything else, TypeScript says ,"'Inner' is referenced directly or indirectly in its own base expression.ts(2506)", which is a load of crap, the code works and we shouldn't force users to add `// @ts-ignore` to their class declarations. This `| any` type is the lesser evil and still provides enough editor hints.